### PR TITLE
[osc] Use busybox compatible commands for completion

### DIFF
--- a/rpm/0009-Use-busybox-compatible-commands-for-completion.patch
+++ b/rpm/0009-Use-busybox-compatible-commands-for-completion.patch
@@ -1,0 +1,30 @@
+commit 9146eb78eb22c59c438b985bf0486adab5292883
+Author: nephros <nemo@pgxperiiia10>
+Date:   Wed Feb 14 10:40:36 2024 +0100
+
+    Use busybox compatible commands for completion
+    
+     - use busybox date(1)
+     - use plain stat(1) for ctime
+     - don't use mv -u
+
+diff --git a/contrib/osc.complete b/contrib/osc.complete
+index a734b615..1c83ca04 100755
+--- a/contrib/osc.complete
++++ b/contrib/osc.complete
+@@ -152,12 +152,12 @@ fi
+ update_projects_list ()
+ {
+     if test -s "${projects}" ; then
+-        typeset -i ctime=$(command date -d "$(command stat -c '%z' ${projects})" +'%s')
+-        typeset -i   now=$(command date -d now +'%s')
++        typeset -i ctime=$(command stat -c '%Z' ${projects})
++        typeset -i   now=$(command date -D -F +'%s')
+         if ((now - ctime > 86400)) ; then
+             if tmp=$(mktemp ${projects}.XXXXXX) ; then
+                 command ${command} ls / >| $tmp
+-	        mv -uf $tmp ${projects}
++	        mv -f $tmp ${projects}
+ 	    fi
+         fi
+     else

--- a/rpm/osc.spec
+++ b/rpm/osc.spec
@@ -22,6 +22,7 @@ Patch0005:      0005-Add-support-for-rebuild-and-chroot-only-in-build.-re.patch
 Patch0006:      0006-Add-architecture-and-scheduler-maps.patch
 Patch0007:      0007-Trap-any-kind-of-exception-during-plugin-parsing-eg-.patch
 Patch0008:      0008-Fix-hdrmd5-check-of-downloaded-packages-from-DoD-rep.patch
+Patch0009:      0009-Use-busybox-compatible-commands-for-completion.patch
 BuildRequires:  python3-cryptography
 BuildRequires:  python3-devel
 BuildRequires:  python3-distro


### PR DESCRIPTION
I know it's a bit trivial, but non-busybox-compatible use of `date(1)`
is very annoying when using tab-command-completion

Fixes this behaviour:

    osc s<TAB>

    osc sdate: invalid date '2023-09-20 18:20:56.234292273 +0200'
    date: invalid date 'now'


