### PR TITLE
[osc] Change default API URL to Sailfish OBS

### DIFF
--- a/rpm/0101-default-apiurl.patch
+++ b/rpm/0101-default-apiurl.patch
@@ -1,0 +1,13 @@
+diff --git a/osc/conf.py b/osc/conf.py
+index 07dfc0b9..783d89a7 100644
+--- a/osc/conf.py
++++ b/osc/conf.py
+@@ -483,7 +483,7 @@ class Options(OscOptions):
+     )  # type: ignore[assignment]
+ 
+     apiurl: str = Field(
+-        default="https://api.opensuse.org",
++        default="https://build.sailfishos.org",
+         description=textwrap.dedent(
+             """
+             Default URL to the API server.

--- a/rpm/osc.spec
+++ b/rpm/osc.spec
@@ -22,6 +22,7 @@ Patch0005:      0005-Add-support-for-rebuild-and-chroot-only-in-build.-re.patch
 Patch0006:      0006-Add-architecture-and-scheduler-maps.patch
 Patch0007:      0007-Trap-any-kind-of-exception-during-plugin-parsing-eg-.patch
 Patch0008:      0008-Fix-hdrmd5-check-of-downloaded-packages-from-DoD-rep.patch
+Patch0101:      0101-default-apiurl.patch
 BuildRequires:  python3-cryptography
 BuildRequires:  python3-devel
 BuildRequires:  python3-distro


### PR DESCRIPTION
... so new users don't need to change it after initial install

